### PR TITLE
Don't include release "tags" pages in the sitemap

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -370,6 +370,7 @@ module.exports = {
         },
         sitemap: {
           changefreq: "weekly",
+          ignorePatterns: ["**/releases/tags/**"],
           priority: 0.5,
         },
       },


### PR DESCRIPTION
#### Description

These are pages like https://mondoo.com/docs/releases/tags/mondoo/ or https://mondoo.com/docs/releases/tags/mondoo/page/2/ which are going to get flagged as duplicates by Google and just clog up the indexing.

#### Related issue

N/A

#### Types of changes

<!--- What types of changes does this merge request introduce? Put an `x` in all the boxes that apply: -->

- [ ] Functional documentation bug fix (i.e., broken link or some other busted behavior)
- [ ] New functional doc capabilities (i.e., filter search results)
- [ ] New content
- [ ] Revision to existing content
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

#### Checklist

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, please ask. We're here to help! -->

- [x] I have read the **README** document about contributing to this repo.
- [x] I have tested my changes locally and there are no issues.
- [x] All commits are signed.
