### PR TITLE
Add a redirect for a URL we add to AWS assets

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -5,7 +5,7 @@ const { themes } = require("prism-react-renderer");
 const legacyRedirects = [
   // NOTE: Path / is equivalent to https://mondoo.com/docs/
   //
-  // This is a URL that Mondoo added to AWS resources via the AWS integration CloudFormation```
+  // This is a URL that Mondoo added to AWS resources via the AWS integration CloudFormation
   // Don't delete it unless the product changes:
   {
     from: "/cloud/aws/overview",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -5,6 +5,12 @@ const { themes } = require("prism-react-renderer");
 const legacyRedirects = [
   // NOTE: Path / is equivalent to https://mondoo.com/docs/
   //
+  // This is a URL that Mondoo adds to new integrations
+  // Don't delete it unless the product changes:
+  {
+    from: "/cloud/aws/overview",
+    to: "platform/cloud/aws/aws-overview",
+  },
   // march 2024 moved cnspec cloud content into one dir
   {
     from: "/cnspec/cnspec-aws/cnspec-aws-account",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -5,7 +5,7 @@ const { themes } = require("prism-react-renderer");
 const legacyRedirects = [
   // NOTE: Path / is equivalent to https://mondoo.com/docs/
   //
-  // This is a URL that Mondoo adds to new integrations
+  // This is a URL that Mondoo added to AWS resources via the AWS integration CloudFormation```
   // Don't delete it unless the product changes:
   {
     from: "/cloud/aws/overview",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -9,7 +9,7 @@ const legacyRedirects = [
   // Don't delete it unless the product changes:
   {
     from: "/cloud/aws/overview",
-    to: "platform/cloud/aws/aws-overview",
+    to: "platform/infra/cloud/aws/aws-overview",
   },
   // march 2024 moved cnspec cloud content into one dir
   {


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

#### Description

Per @tas50, Mondoo adds a doc tag to each asset when we create a new integration. It has a URL that doesn't exist. So this adds a redirect for that URL.

#### Related issue

n/a

#### Types of changes

<!--- What types of changes does this merge request introduce? Put an `x` in all the boxes that apply: -->

- [x] Functional documentation bug fix (i.e., broken link or some other busted behavior)
- [ ] New functional doc capabilities (i.e., filter search results)
- [ ] New content
- [ ] Revision to existing content
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

#### Checklist

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, please ask. We're here to help! -->

- [x] I have read the **README** document about contributing to this repo.
- [x] I have tested my changes locally and there are no issues.
- [x] All commits are signed.
