### PR TITLE
Fix platform docs link

### DIFF
--- a/docs/cnquery/README.md
+++ b/docs/cnquery/README.md
@@ -104,7 +104,7 @@ cnquery help run
 
 To more easily explore your infrastructure, sign up for a free Mondoo Platform account. Mondoo's web-based console allows you to navigate, search, and inspect all of your assets.
 
-To learn about Mondoo Platform, read the [Mondoo Platform docs](../intro.md) or visit [mondoo.com](https://mondoo.com).
+To learn about Mondoo Platform, read the [Mondoo Platform docs](../platform/home.md) or visit [mondoo.com](https://mondoo.com).
 
 To learn how to sign up for a free Mondoo account and register cnquery, read [Log into Mondoo Platform for More Capabilities](/cnquery/cnquery-platform/).
 

--- a/docs/cnquery/_cnquery-explore.md
+++ b/docs/cnquery/_cnquery-explore.md
@@ -38,6 +38,6 @@ To more easily explore your infrastructure, sign up for a free Mondoo Platform a
 
 Go to [console.mondoo.com](https://console.mondoo.com) to sign up.
 
-To learn about Mondoo Platform, read the [Mondoo Platform docs](../intro.md) or visit [mondoo.com](https://mondoo.com).
+To learn about Mondoo Platform, read the [Mondoo Platform docs](../platform/home.md) or visit [mondoo.com](https://mondoo.com).
 
 ---

--- a/docs/cnquery/cnquery-about.mdx
+++ b/docs/cnquery/cnquery-about.mdx
@@ -26,7 +26,7 @@ Our query language is MQL, which combines a graph database approach and powerful
 
 To more easily explore your infrastructure, sign up for a [free Mondoo Platform](https://console.mondoo.com) account. Mondoo's web-based console allows you to navigate, search, and inspect all of your assets.
 
-To learn about Mondoo Platform, read the [Mondoo Platform docs](../intro.md) or visit [mondoo.com](https://mondoo.com).
+To learn about Mondoo Platform, read the [Mondoo Platform docs](../platform/home.md) or visit [mondoo.com](https://mondoo.com).
 
 To learn how to sign up for a free Mondoo account and register cnquery, read [Log into Mondoo Platform for More Capabilities](/cnquery/cnquery-platform/).
 

--- a/docs/cnquery/cnquery-run-pack.md
+++ b/docs/cnquery/cnquery-run-pack.md
@@ -70,6 +70,6 @@ To more easily explore your infrastructure, sign up for a free Mondoo Platform a
 
 Go to [console.mondoo.com](https://console.mondoo.com) to sign up.
 
-To learn about Mondoo Platform, read the [Mondoo Platform docs](../intro.md) or visit [mondoo.com](https://mondoo.com).
+To learn about Mondoo Platform, read the [Mondoo Platform docs](../platform/home.md) or visit [mondoo.com](https://mondoo.com).
 
 ---


### PR DESCRIPTION
#### Description

These links were just going to /docs/ before which didn't make sense

#### Related issue

<!--- Provide a link to the GitHub issue this fixes. -->

#### Types of changes

<!--- What types of changes does this merge request introduce? Put an `x` in all the boxes that apply: -->

- [ ] Functional documentation bug fix (i.e., broken link or some other busted behavior)
- [ ] New functional doc capabilities (i.e., filter search results)
- [ ] New content
- [x] Revision to existing content
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

#### Checklist

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, please ask. We're here to help! -->

- [x] I have read the **README** document about contributing to this repo.
- [x] I have tested my changes locally and there are no issues.
- [x] All commits are signed.
