### PR TITLE
docs: Added instructions on how to fix hostname changes

### DIFF
--- a/docs/cnspec/cnspec-adv-install/macos.mdx
+++ b/docs/cnspec/cnspec-adv-install/macos.mdx
@@ -54,16 +54,13 @@ To install the PKG non-interactively use the _installer_ utility in a Terminal:
 installer -pkg ./mondoo_(version)_darwin_universal.pkg -target /Library
 ```
 
-## Mitigating Hostname Changes
+## Mitigate hostname changes
 
-Sometimes under MacOS, when changing locations and having different networks, the Mac can change its hostname, resulting in two or more entries for the same workstation in the Mondoo dashboard when a test is run. To mitigate this problem, you can edit the Mondoo configuration file (`mondoo.yml`) and add the following line:
+Sometimes when changing locations and networks, macOS devices can change their hostnames. When this happens, you see two or more entries for the same workstation in the Mondoo Console. To mitigate this problem, open the Mondoo configuration file located at ~/.config/mondoo/mondoo.yml and add this line:
 
 ```yaml
 id-detector: machine-id
 ```
-
-The CLI configuration file is located at ~/.config/mondoo/mondoo.yml on Linux and macOS, and %HomePath%\mondoo\mondoo.yml on Windows.
-
 
 ## Learn more
 

--- a/docs/cnspec/cnspec-adv-install/macos.mdx
+++ b/docs/cnspec/cnspec-adv-install/macos.mdx
@@ -54,6 +54,17 @@ To install the PKG non-interactively use the _installer_ utility in a Terminal:
 installer -pkg ./mondoo_(version)_darwin_universal.pkg -target /Library
 ```
 
+## Mitigating Hostname Changes
+
+Sometimes under MacOS, when changing locations and having different networks, the Mac can change its hostname, resulting in two or more entries for the same workstation in the Mondoo dashboard when a test is run. To mitigate this problem, you can edit the Mondoo configuration file (`mondoo.yml`) and add the following line:
+
+```yaml
+id-detector: machine-id
+```
+
+The CLI configuration file is located at ~/.config/mondoo/mondoo.yml on Linux and macOS, and %HomePath%\mondoo\mondoo.yml on Windows.
+
+
 ## Learn more
 
 - [Register cnspec](/cnspec/cnspec-adv-install/registration)


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
I added the instruction to add `id-detector: machine-id` to the `mondoo.yml` config if the hostname changes names. 

#### Description

<!--- Describe your changes in detail. What problems do they solve? -->
I noticed that I have two asset records for my MacBook in our workstation integration. I use my notebook in multiple locations. I get two different asset and integration entries for my workstation, but I have not logged in with a new token and have only run the local Cnspec scan with the same config. I have been working from three locations: One is called "MBP-von_Paul.fritz.box" and the other two are called "MacBook-Pro-von-Paul.local". After communicating with @atomic111, I was asked to add this note.

#### Related issue

<!--- Provide a link to the GitHub issue this fixes. -->

See workspace-infralovers [issue](https://github.com/mondoo-community/workspace-infralovers/issues/19).

#### Types of changes

<!--- What types of changes does this merge request introduce? Put an `x` in all the boxes that apply: -->

- [ ] Functional documentation bug fix (i.e., broken link or some other busted behavior)
- [ ] New functional doc capabilities (i.e., filter search results)
- [x] New content
- [ ] Revision to existing content
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

#### Checklist

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, please ask. We're here to help! -->

- [x] I have read the **README** document about contributing to this repo.
- [x] I have tested my changes locally and there are no issues.
- [x] All commits are signed.
