### PR TITLE
Fix output + branding for Azure examples

### DIFF
--- a/docs/cnspec/cloud/azure/README.mdx
+++ b/docs/cnspec/cloud/azure/README.mdx
@@ -173,18 +173,22 @@ From the resulting list, you can drill down even further. You can also learn abo
 
 Now that you know how to discover what's possible with cnspec, let's run some actual tests in the shell.
 
-#### Assess SQL server auditing
+#### Assess Azure SQL Database auditing policy
 
-This test assures that auditing is turned on for your SQL servers:
+This test assures that auditing is turned on for your Azure SQL Database instances:
 
 ```bash
 azure.subscription.sql.servers { auditingPolicy['state'] == "Enabled" }
 ```
 
-If the test passes (all SQL servers have auditing enabled) then cnspec returns `ok`:
+If the test passes (all servers have auditing enabled) then cnspec returns `true` for each server:
 
 ```coffeescript
-[ok] value: true
+azure.subscription.sql.servers: [
+  0: {
+    auditingPolicy.state == "Enabled": true
+  }
+]
 ```
 
 If the test fails, (one or more Cloud Storage buckets don't use uniform bucket-level access) then cnspec provides details about the failure.


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

#### Description

- We don't just output true on a pass now
- The product is called Azure SQL Database and it has one of the most terribly confusing set of names / terms that shows that it has been rebranded at least twice.

#### Related issue

<!--- Provide a link to the GitHub issue this fixes. -->

#### Types of changes

<!--- What types of changes does this merge request introduce? Put an `x` in all the boxes that apply: -->

- [ ] Functional documentation bug fix (i.e., broken link or some other busted behavior)
- [ ] New functional doc capabilities (i.e., filter search results)
- [ ] New content
- [x] Revision to existing content
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

#### Checklist

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, please ask. We're here to help! -->

- [x] I have read the **README** document about contributing to this repo.
- [x] I have tested my changes locally and there are no issues.
- [x] All commits are signed.
