### PR TITLE
Use the new socials links feature in docu 3.4

### DIFF
--- a/releases/authors.yml
+++ b/releases/authors.yml
@@ -3,6 +3,9 @@ tim:
   title: Mondoo Core Team
   url: https://github.com/tas50
   image_url: https://github.com/tas50.png
+  socials:
+    linkedin: tsmith84
+    github: tas50
 
 chip:
   name: Charles Johnson


### PR DESCRIPTION
#### Description

This puts the icons for socials in the authors section automatically similar to our blog

<img width="586" alt="image" src="https://github.com/user-attachments/assets/d106eed6-cb2d-4650-91bd-4a46c5ea1402">

#### Related issue

<!--- Provide a link to the GitHub issue this fixes. -->

#### Types of changes

<!--- What types of changes does this merge request introduce? Put an `x` in all the boxes that apply: -->

- [ ] Functional documentation bug fix (i.e., broken link or some other busted behavior)
- [x] New functional doc capabilities (i.e., filter search results)
- [ ] New content
- [ ] Revision to existing content
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

#### Checklist

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, please ask. We're here to help! -->

- [x] I have read the **README** document about contributing to this repo.
- [x] I have tested my changes locally and there are no issues.
- [x] All commits are signed.
