### PR TITLE
🧹   Improved the part related to Entra ID permissions

### DIFF
--- a/docs/platform/infra/saas/ms365/_include-graph.mdx
+++ b/docs/platform/infra/saas/ms365/_include-graph.mdx
@@ -28,6 +28,8 @@ By default, Microsoft grants your new application `User.Read` permission for Mic
 | SecurityActions.Read.All               | Application | Read your organization's security actions               |
 | SecurityEvents.Read.All                | Application | Read your organization's security events                |
 | DeviceManagementConfiguration.Read.All | Application | Read Microsoft Intune device configuration and policies |
+| AuditLog.Read.All                      | Application | Read all audit log data                                 |
+| Directory.Read.All                     | Application | Read directory data                                     |
 
 </details>
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

#### Description

This pull request adds the capability to retrieve **subscribed SKUs** (license information) for Microsoft Entra ID (formerly Azure AD) in `cnquery` through the `microsoft.tenant.subscribedSkus` method. This functionality allows users to verify license details directly, which is essential for determining eligibility for features like MFA (Multi-Factor Authentication) based on license tiers (e.g., Premium P1 or P2).

Additionally, we have included two new Microsoft Graph API permissions required for these changes:
- **AuditLog.Read.All** (Application) – Allows the application to read all audit log data, enhancing the system's logging and troubleshooting capabilities.
- **Directory.Read.All** (Application) – Provides read access to directory data, enabling retrieval of license details and directory metadata.

These permissions ensure the necessary access for retrieving license information securely and accurately.

#### Related issue

<!--- Provide a link to the GitHub issue this fixes. -->
#1144

#### Types of changes

<!--- What types of changes does this merge request introduce? Put an `x` in all the boxes that apply: -->

- [] New content
- [x] Revision to existing content
- [ ] Functional documentation bug fix (i.e., broken link or some other busted behavior)
- [ ] New functional doc capabilities (i.e., filter search results)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

#### Checklist

- [x] I have read the **README** document about contributing to this repo.
- [x] I have tested my changes locally, and there are no issues.
- [x] All commits are signed.
