### PR TITLE
Add a make command to generate release notes

### DIFF
--- a/.github/actions/spelling/excludes.txt
+++ b/.github/actions/spelling/excludes.txt
@@ -81,3 +81,4 @@ ignore$
 \.zip$
 ^\.github/actions/spelling/
 ^\Q.github/workflows/spelling.yml\E$
+_release_template_file.md

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,8 @@ notes:
 	@echo "Generating new release note file\n\n"
 	@read -p 'What version should I use? ' VERSION; \
 	read -p 'What date will this release ship (ex: 2024-11-05)? ' DATE; \
-	cp ./releases/_release_template_file.md ./releases/$${DATE}-mondoo-$${VERSION}-is-out.md; \
-	mkdir -p ./static/img/releases/$${DATE}-mondoo-$${VERSION}-is-out; \
+	cp ./releases/_release_template_file.md "./releases/$${DATE}-mondoo-$${VERSION}-is-out.md"; \
+	mkdir -p "./static/img/releases/$${DATE}-mondoo-$${VERSION}-is-out"; \
 	sed -i '' "s/VERSION/$${VERSION}/g" "./releases/$${DATE}-mondoo-$${VERSION}-is-out.md"
 
 ###

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,19 @@ serve: yarn fmt build
 	yarn run serve
 
 ###
+### Create a new release note
+###
+
+.PHONY: notes
+notes:
+	@echo "Generating new release note file\n\n"
+	@read -p 'What version should I use? ' VERSION; \
+	read -p 'What date will this release ship (ex: 2024-11-05)? ' DATE; \
+	cp ./releases/_release_template_file.md ./releases/$${DATE}-mondoo-$${VERSION}-is-out.md; \
+	mkdir -p ./static/img/releases/$${DATE}-mondoo-$${VERSION}-is-out; \
+	sed -i '' "s/VERSION/$${VERSION}/g" "./releases/$${DATE}-mondoo-$${VERSION}-is-out.md"
+
+###
 ### Caddy
 ###
 .PHONY: caddy/run

--- a/releases/_release_template_file.md
+++ b/releases/_release_template_file.md
@@ -1,0 +1,38 @@
+---
+slug: mondoo-VERSION-is-out/
+title: Mondoo VERSION is out!
+description: Announcing the VERSION release of Mondoo with FOO, BAR, BAZ, and more!
+authors: [tim]
+image: DEETS
+tags: [release, mondoo]
+---
+
+## 🥳 Mondoo VERSION is out! This release includes FOO, BAR, BAZ, and more!
+
+Get this release: [Installation Docs](https://mondoo.com/docs/cnspec/) | [Package Downloads](https://releases.mondoo.com/cnspec/) | [Docker Container](https://hub.docker.com/r/mondoo/cnspec)
+
+---
+
+## 🎉 NEW FEATURES
+
+### FEATURE 1
+
+DEETS
+
+## 🧹 IMPROVEMENTS
+
+### IMPROVEMENT 1
+
+DEETS
+
+### Resource updates
+
+#### RESOURCE 1
+
+- New `FIELD_NAME` field
+- New `FIELD_NAME` field using the new `MQL.RESOURCE` resource
+
+## 🐛 BUG FIXES AND UPDATES
+
+- BUG 1
+- BUG 2


### PR DESCRIPTION
#### Description

I was wasting time copying the last one each time and then changing things to make it a template that I could use for the next week. Why not automate this a bit?

#### Related issue

<!--- Provide a link to the GitHub issue this fixes. -->

#### Types of changes

<!--- What types of changes does this merge request introduce? Put an `x` in all the boxes that apply: -->

- [ ] Functional documentation bug fix (i.e., broken link or some other busted behavior)
- [x] New functional doc capabilities (i.e., filter search results)
- [ ] New content
- [ ] Revision to existing content
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

#### Checklist

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, please ask. We're here to help! -->

- [x] I have read the **README** document about contributing to this repo.
- [x] I have tested my changes locally and there are no issues.
- [x] All commits are signed.
