### PR TITLE
Updates K8s node scanning documentation

### DIFF
--- a/docs/platform/infra/cloud/kubernetes/scan-kubernetes-with-operator.md
+++ b/docs/platform/infra/cloud/kubernetes/scan-kubernetes-with-operator.md
@@ -48,11 +48,17 @@ import Partial from "../../../partials/\_editor-owner.mdx";
 
 3. To continuously assess the security posture of nodes in your Kubernetes cluster, enable **Scan nodes**.
 
-   Choose how to scan cluster nodes:
+:::important
 
-   - We strongly recommend that you leave **CronJob-based** selected. It's ideal for most infrastructures. A CronJob executes regularly to run the scans without permanently allocating any resources for Mondoo on cluster nodes.
+Mondoo can scan both a Kubernetes (K8s) cluster using the Mondoo K8s Operator and the account (AWS account, GCP project, or Azure subscription) where the cluster is deployed. To avoid duplication of assets, if the account is integrated with VM scanning enabled, or if you plan to enable it, ensure that Node Scanning is disabled for the Kubernetes cluster.
 
-   - If your nodes tend to run near 100% resource utilization, that leaves no resources available for a CronJob to run a Mondoo scan. If you experience consistently failing Mondoo node scans, select **DaemonSet-based** scanning instead. This approach reserves resources for Mondoo on each cluster node. It relies on a DaemonSet to assure that Mondoo scans the nodes continuously, even during high-traffic times.
+:::
+
+Choose how to scan cluster nodes:
+
+- We strongly recommend that you leave **CronJob-based** selected. It's ideal for most infrastructures. A CronJob executes regularly to run the scans without permanently allocating any resources for Mondoo on cluster nodes.
+
+- If your nodes tend to run near 100% resource utilization, that leaves no resources available for a CronJob to run a Mondoo scan. If you experience consistently failing Mondoo node scans, select **DaemonSet-based** scanning instead. This approach reserves resources for Mondoo on each cluster node. It relies on a DaemonSet to assure that Mondoo scans the nodes continuously, even during high-traffic times.
 
 4. To continuously assess the security posture of workloads and resources in your cluster, enable **Scan workloads**.
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

#### Description

![image](https://github.com/user-attachments/assets/bd923509-c68d-4507-92e0-2513c5ea2f22)

From @imilchev : 

>the mondoo-operator uses filesystem scanning to scan the k8s nodes. That cannot check all the stuff we normally check. On the container-optimized operating systems we may be locked out of having access to /proc or to the root filesystem. This means some checks may results in ERROR results. This is what is happening in lunalectric. The operator gets ERROR results for some checks, which pass when scanning the same node from AWS Serverless integration. You get flopping check results.
>There is also a bigger problem than just this. Mondoo is no configured to scan the same asset from 2 different integrations. We never supported that and we still don’t. If the 2 integrations happen to scan the asset at the same time in parallel, you are definitely getting weird results in the UI. On top of that, if you open an asset, you can see which integration “owns” the asset. If you scan the same asset from multiple integrations, that information will be inaccurate. One time it may say the asset is owned by integration A and the next time it may be integration B. Asset overview table also gets different info based on what integration scanned the asset. In your case the asset name also changes because the mondoo-operator uses the node name in the cluster as asset name. However, AWS Serverless is using the EC2 name as asset name.
>Bottom line is, you should NOT scan the same thing with different integrations. That is only opening the door for all kinds of weird results. On top of that, at the moment, we don’t offer any additional value if you try to do this. You are just performing unnecessary work (because you are scanning something you already scanned again). If you have AWS serverless integration running, which scans EC2 instances, there is no benefit and no point at all to use node scanning with the mondoo-operator
>All clouds. It’s the same concept. It’s similar to scanning a linux server with a cnspec service but also running an ssh scan from somewhere else. It really gives you no extra info, you are just scanning the same thing twice

#### Related issue

<!--- Provide a link to the GitHub issue this fixes. -->

#### Types of changes

<!--- What types of changes does this merge request introduce? Put an `x` in all the boxes that apply: -->

- [ ] Functional documentation bug fix (i.e., broken link or some other busted behavior)
- [ ] New functional doc capabilities (i.e., filter search results)
- [ ] New content
- [x] Revision to existing content
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

#### Checklist

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, please ask. We're here to help! -->

- [x] I have read the **README** document about contributing to this repo.
- [x] I have tested my changes locally and there are no issues.
- [x] All commits are signed.
