### PR TITLE
Fix sample scan command to include mandatory default vsphere domain

### DIFF
--- a/docs/platform/infra/cloud/vmware.md
+++ b/docs/platform/infra/cloud/vmware.md
@@ -241,7 +241,7 @@ sudo cnspec login -t <paste token here> --config /etc/opt/mondoo/mondoo.yml
 
 ```bash
 # vSphere 6.x / 7.x
-cnspec scan vsphere user@host --ask-pass
+cnspec scan vsphere mondoo-read@vsphere.local@host --ask-pass
 ```
 
 4. Activate the policies against which Mondoo assesses your VMware.
@@ -253,7 +253,7 @@ A good place to start scanning is the `VMware vSphere ESXi Security Baseline by 
 5. Now, with the policy of your choice activated, scan again:
 
 ```bash
-cnspec scan vsphere user@host --ask-pass
+cnspec scan vsphere mondoo-read@vsphere.local@host --ask-pass
 ```
 
 Because you did not pass the `--incognito` switch, the command output includes a link to the Mondoo Console, where you can review the scan results.


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

#### Description

the sample scan command now includes the default vcenter domain, using just the mondoo-read user is not sufficient.
#### Related issue

<!--- Provide a link to the GitHub issue this fixes. -->

#### Types of changes

<!--- What types of changes does this merge request introduce? Put an `x` in all the boxes that apply: -->

- [ ] Functional documentation bug fix (i.e., broken link or some other busted behavior)
- [ ] New functional doc capabilities (i.e., filter search results)
- [ ] New content
- [x] Revision to existing content
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

#### Checklist

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, please ask. We're here to help! -->

- [x] I have read the **README** document about contributing to this repo.
- [x] I have tested my changes locally and there are no issues.
- [x] All commits are signed.
