### PR TITLE
Remove expand/collapse from MS permissions required

### DIFF
--- a/docs/cnspec/cloud/azure/README.mdx
+++ b/docs/cnspec/cloud/azure/README.mdx
@@ -85,9 +85,9 @@ cnspec scan azure --subscription YOUR-SUBSCRIPTION-ID
 
 cnspec follows these steps to load policies on which it bases the scan:
 
-- cnspec tries to read a config file, mondoo.yml, which includes the certificate and private key for authenticating with Mondoo Platform. If it finds the config, it loads the policies enabled for the Azure integration in the Mondoo space this Azure environment belongs to. You can enter `cnspec status` to see if the config file exists and cnspec is registered.
+1. cnspec tries to read a config file, mondoo.yml, which includes the certificate and private key for authenticating with Mondoo Platform. If it finds the config, it loads the policies enabled for the Azure integration in the Mondoo space this Azure environment belongs to. You can enter `cnspec status` to see if the config file exists and cnspec is registered.
 
-2.  If there is no config file (you have not registered cnspec or you've removed the mondoo.yml file), then cnspec loads Mondoo's open source policies and scans based on those.
+2. If there is no config file (you have not registered cnspec or you've removed the mondoo.yml file), then cnspec loads Mondoo's open source policies and scans based on those.
 
 :::info
 

--- a/docs/platform/infra/cloud/azure/_include-graph.mdx
+++ b/docs/platform/infra/cloud/azure/_include-graph.mdx
@@ -16,11 +16,6 @@
 
 5. Select **expand all** to see all permissions. Then select the required API permissions:
 
-   {" "}
-
-<details>
-<summary>Show or hide required API permissions.</summary>
-
 | Microsoft Graph               | Type        | Description                                          |
 | ----------------------------- | ----------- | ---------------------------------------------------- |
 | Application.Read.All          | Application | Read all applications                                |
@@ -38,8 +33,6 @@
 | SecurityEvents.Read.All       | Application | Read your organization's security events             |
 | ThreatAssessment.Read.All     | Application | Read threat assessment requests                      |
 | ThreatIndicators.Read.All     | Application | Read all threat indicators                           |
-
-</details>
 
 6. Select the **Add permissions** button.
 

--- a/docs/platform/infra/saas/ms365/_include-graph.mdx
+++ b/docs/platform/infra/saas/ms365/_include-graph.mdx
@@ -16,9 +16,6 @@ By default, Microsoft grants your new application `User.Read` permission for Mic
 
 5. Select **expand all** to see all permissions. Then select the required API permissions:
 
-<details>
-<summary>Show or hide required API permissions.</summary>
-
 | Microsoft Graph                        | Type        | Description                                             |
 | -------------------------------------- | ----------- | ------------------------------------------------------- |
 | IdentityProvider.Read.All              | Application | Read identity providers                                 |
@@ -30,8 +27,6 @@ By default, Microsoft grants your new application `User.Read` permission for Mic
 | DeviceManagementConfiguration.Read.All | Application | Read Microsoft Intune device configuration and policies |
 | AuditLog.Read.All                      | Application | Read all audit log data                                 |
 | Directory.Read.All                     | Application | Read directory data                                     |
-
-</details>
 
 6. Select the **Add permissions** button.
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

#### Description

@AdamVB reports that more than one customer has skipped past the required permissions in our MS 365 instructions. So this PR removes the expand/collapse feature in both MS 365 and Azure integration docs. 

#### Related issue

none

#### Types of changes

<!--- What types of changes does this merge request introduce? Put an `x` in all the boxes that apply: -->

- [ ] Functional documentation bug fix (i.e., broken link or some other busted behavior)
- [ ] New functional doc capabilities (i.e., filter search results)
- [ ] New content
- [x] Revision to existing content
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

#### Checklist

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, please ask. We're here to help! -->

- [x] I have read the **README** document about contributing to this repo.
- [x] I have tested my changes locally and there are no issues.
- [x] All commits are signed.
