### PR TITLE
Remove filter on policy level

### DIFF
--- a/docs/cnspec/cnspec-policies/write/_filter-policy.mdx
+++ b/docs/cnspec/cnspec-policies/write/_filter-policy.mdx
@@ -1,0 +1,43 @@
+Removing this from the docs for now because we don't support it. However, we will support it soon. So I'm stashing this content in this file that DOES NOT GET COMPILED for safe keeping.
+
+## Apply a filter to a policy
+
+The policy in this bundle has a filter:
+
+<!-- prettier-ignore-start -->
+```yaml showLineNumbers
+policies:
+  - uid: ssh-with-filter
+    name: SSH policy that uses a filter
+
+...
+
+    groups:
+      - title: my-group
+        checks:
+          - uid: sshd-01
+            title: Ensure the port is set to 22
+            mql: sshd.config.params["Port"] == 22
+            impact: 30
+
+          - uid: sshd-02
+            title: Prevent weaker CBC ciphers from being used
+            mql: sshd.config.ciphers.none( /cbc/ )
+            impact: 60
+
+        queries:
+          - uid: sshd-d-1
+            title: Gather SSH config params
+            mql: sshd.config.params
+
+        filters:
+          - mql: asset.family.contains('unix')
+```
+<!-- prettier-ignore-end -->
+
+This bundle contains only one policy, `ssh-with-filter`. The section beginning on line 24 defines _filters_ for the policy. In this case, cnspec uses the policy to scan only assets that are based on UNIX (Linux distributions and macOS).
+
+import Partial from "./_include-lint.mdx";
+
+<Partial />{" "}
+

--- a/docs/cnspec/cnspec-policies/write/filters.mdx
+++ b/docs/cnspec/cnspec-policies/write/filters.mdx
@@ -54,47 +54,6 @@ groups:
 
 Unless the asset is an AWS compute service, cnspec skips all the checks and queries in this group when scanning the asset.
 
-## Apply a filter to a policy
-
-The policy in this bundle has a filter:
-
-<!-- prettier-ignore-start -->
-```yaml showLineNumbers
-policies:
-  - uid: ssh-with-filter
-    name: SSH policy that uses a filter
-
-...
-
-    groups:
-      - title: my-group
-        checks:
-          - uid: sshd-01
-            title: Ensure the port is set to 22
-            mql: sshd.config.params["Port"] == 22
-            impact: 30
-
-          - uid: sshd-02
-            title: Prevent weaker CBC ciphers from being used
-            mql: sshd.config.ciphers.none( /cbc/ )
-            impact: 60
-
-        queries:
-          - uid: sshd-d-1
-            title: Gather SSH config params
-            mql: sshd.config.params
-
-        filters:
-          - mql: asset.family.contains('unix')
-```
-<!-- prettier-ignore-end -->
-
-This bundle contains only one policy, `ssh-with-filter`. The section beginning on line 24 defines _filters_ for the policy. In this case, cnspec uses the policy to scan only assets that are based on UNIX (Linux distributions and macOS).
-
-import Partial from "./_include-lint.mdx";
-
-<Partial />{" "}
-
 ## More examples of filters
 
 This filter limits scans to only GCP projects:


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

#### Description

In the policy authoring docs:
We currently do not support filtering at the policy level so I'm removing it. However, we do plan to add it soon. So I've stashed it in an mdx file that does not get compiled in the documentation.

#### Related issue

https://github.com/mondoohq/docs/issues/449

#### Types of changes

<!--- What types of changes does this merge request introduce? Put an `x` in all the boxes that apply: -->

- [ ] Functional documentation bug fix (i.e., broken link or some other busted behavior)
- [ ] New functional doc capabilities (i.e., filter search results)
- [ ] New content
- [x] Revision to existing content
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

#### Checklist

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, please ask. We're here to help! -->

- [x] I have read the **README** document about contributing to this repo.
- [x] I have tested my changes locally and there are no issues.
- [x] All commits are signed.
