### PR TITLE
Scanning private Github repositories requires a different scope for the personal access token

### DIFF
--- a/docs/cnspec/saas/github.md
+++ b/docs/cnspec/saas/github.md
@@ -41,6 +41,12 @@ To learn how to create a personal access token, read [Managing your personal acc
 - admin:org_hook
 - read:project
 
+:::note
+
+If you would also like to scan private repositories, you need to select the entire **repo** scope instead of only **public_repo**.
+
+:::
+
 #### Configure a GITHUB_TOKEN environment variable
 
 You supply your personal access token to cnspec by setting the `GITHUB_TOKEN` environment variable.


### PR DESCRIPTION
#### Description

Added the note that in order to scan private repositories as well, the entire repo scope has to be selected for the personal access token. Otherwise the query will fail if no organization is provided and only repositories should be scanned.

#### Related issue

n/a

#### Types of changes

- [ ] Functional documentation bug fix (i.e., broken link or some other busted behavior)
- [ ] New functional doc capabilities (i.e., filter search results)
- [ ] New content
- [x] Revision to existing content
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

#### Checklist

- [x] I have read the **README** document about contributing to this repo.
- [x] I have tested my changes locally and there are no issues.
- [x] All commits are signed.
