### PR TITLE
M365 - Specify Subscription not required

### DIFF
--- a/docs/platform/infra/saas/ms365/ms365-auto.md
+++ b/docs/platform/infra/saas/ms365/ms365-auto.md
@@ -231,15 +231,7 @@ After you've created and granted permissions to a new app registration, you can 
 
 4. In the **Enter the directory (tenant) ID** box, enter the value from the app registration's **Directory (tenant) ID** box.
 
-5. Specify the subscriptions for Mondoo to continuously scan.
-
-   - To continuously scan all subscriptions in the tenant, leave the **Scan all subscriptions connected to the directory (tenant) ID** toggle enabled.
-
-   - To choose the subscriptions to scan, disable the **Scan all subscriptions connected to the directory (tenant) ID** toggle, select **Allow list** and enter the subscription ID to scan.
-
-   - To scan **all** subscriptions except those you specify, disable the **Scan all subscriptions connected to the directory (tenant) ID** toggle, select **Deny list** and enter the names of the subscriptions you don't want Mondoo to scan.
-
-6. Provide a certificate (a [PEM](https://aboutssl.org/what-is-pem-certificate-file/) (privacy-enhanced mail) file) for Mondoo to securely authenticate with the app (service principal) you created.
+5. Provide a certificate (a [PEM](https://aboutssl.org/what-is-pem-certificate-file/) (privacy-enhanced mail) file) for Mondoo to securely authenticate with the app (service principal) you created.
 
 The certificate file must have the `.pem` extension and must contain both the private key and the certificate in this order:
 


### PR DESCRIPTION
#### Description

Removed point 5 of the M365 integration setup which specified a subscription. This selection is not available in the integration when setting it up in the platform.

Please see as reference the attached screenshot of the current M365 integration page

![M365-integration](https://github.com/user-attachments/assets/58426b6b-7010-49fb-a886-111e22588e44)

#### Types of changes

- [ ] Functional documentation bug fix (i.e., broken link or some other busted behavior)
- [ ] New functional doc capabilities (i.e., filter search results)
- [ ] New content
- [x] Revision to existing content
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

#### Checklist

- [x] I have read the **README** document about contributing to this repo.
- [x] I have tested my changes locally and there are no issues.
- [x] All commits are signed.
