### PR TITLE
🧹 try to continue on imgcmp failure

### DIFF
--- a/.github/workflows/image-optimize.yaml
+++ b/.github/workflows/image-optimize.yaml
@@ -23,3 +23,4 @@ jobs:
       - uses: 9sako6/imgcmp@v2.0.4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true


### PR DESCRIPTION
The error we are getting makes the run fail altogether. Allow it to fail gracefully and move forward.

See: https://github.com/mondoohq/docs/actions/runs/15219755988/job/42813053295
