### PR TITLE
BigQuery Exporter needs bigquery.jobs.create permission

### DIFF
--- a/docs/platform/maintain/export/bigquery-integration.mdx
+++ b/docs/platform/maintain/export/bigquery-integration.mdx
@@ -42,11 +42,11 @@ Your BigQuery integration needs a GCP BigQuery dataset to which to export data. 
 
    For instructions, read [Creating datasets](https://cloud.google.com/bigquery/docs/datasets) in the Google documentation.
 
-2. Assign the "BigQuery Data Editor" role to the GCP service account you created in the instructions above.
+2. Assign the "BigQuery Data Editor" and "BigQuery User" roles to the GCP service account you created in the instructions above.
 
    For instructions, read [Grant access to a dataset](https://cloud.google.com/bigquery/docs/control-access-to-resources-iam#grant_access_to_a_dataset) in the Google documentation.
 
-   For a description of the permissions that the "BigQuery Data Editor" role grants, read [Understanding roles](https://cloud.google.com/iam/docs/understanding-roles#bigquery-roles) in the Google documentation.
+   For a description of the permissions that the "BigQuery User" and "BigQuery Data Editor" roles grant, read [Understanding roles](https://cloud.google.com/iam/docs/understanding-roles#bigquery-roles) in the Google documentation.
 
 ## Add a new BigQuery integration
 


### PR DESCRIPTION
#### Description

Updated the documents for the bigquery exporter to also require the 'BigQuery User' role, due to the need for the `bigquery.jobs.create` permission
#### Related issue
-
#### Types of changes

- [ ] Functional documentation bug fix (i.e., broken link or some other busted behavior)
- [ ] New functional doc capabilities (i.e., filter search results)
- [ ] New content
- [x] Revision to existing content
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

#### Checklist

- [x] I have read the **README** document about contributing to this repo.
- [x] I have tested my changes locally and there are no issues.
- [x] All commits are signed.
