### PR TITLE
Add instructions for Gitlab scan from within CI/CD pipeline

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -114,6 +114,7 @@ geomatchstatement
 getenv
 GGJXG
 gistfile
+GITLABTOKEN
 gmail
 googleusercontent
 gpu
@@ -233,6 +234,7 @@ pcx
 Pesoa
 Pids
 pii
+pipefail
 pki
 pkr
 portgroup

--- a/docs/platform/infra/saas/gitlab.mdx
+++ b/docs/platform/infra/saas/gitlab.mdx
@@ -108,7 +108,7 @@ To set up scanning from a GitLab pipeline:
 
 Now create a GitLab pipeline by creating a [`.gitlab-ci.yml`](https://docs.gitlab.com/ee/ci/yaml/gitlab_ci_yaml.html) configuration file.
 
-This example will create a Gitlab pipeline that scans the instance it is running on using the `mondoo client` Docker image. The scan will run on a schedule you will have to define. You can change discovery options of the scan by changing the `--discover` parameter.
+This example will create a GitLab pipeline that scans the instance it is running on using the `mondoo client` Docker image. The scan will run on a schedule you will have to define. You can change discovery options of the scan by changing the `--discover` parameter.
 
 ```yml title=".gitlab-ci.yml"
 stages: [security]

--- a/docs/platform/infra/saas/gitlab.mdx
+++ b/docs/platform/infra/saas/gitlab.mdx
@@ -93,8 +93,9 @@ To learn more, read [Create a personal access token](https://docs.gitlab.com/ee/
 
 ## Scan GitLab Instance from GitLab CI/CD pipeline
 
-You can also set up a [GitLab pipeline](https://docs.gitlab.com/ee/ci/pipelines/) to scan your GitLab instance. This job can run at your own schedule scanning GitLab groups, GitLab projects, Terraform files and Kubernetes manifests, the same as the Mondoo hosted integration.
-This can be helpful for GitLab instances that have inbound IP allowlists set up to restrict access to the instance. 
+You can also set up a [GitLab pipeline](https://docs.gitlab.com/ee/ci/pipelines/) to scan your GitLab instance. This job can be run on your own schedule. Scanning from a CI/CD pipeline offers the same functionality as the Mondoo hosted integration. 
+GitLab groups, GitLab projects, Terraform files, and Kubernetes manifests can be scanned.
+Running a scan from a CI/CD pipeline can be helpful for GitLab instances that have inbound IP allowlists set up to restrict access to the instance. 
 
 To set up scanning from a GitLab pipeline:
 

--- a/docs/platform/infra/saas/gitlab.mdx
+++ b/docs/platform/infra/saas/gitlab.mdx
@@ -91,6 +91,42 @@ To learn more, read [Create a personal access token](https://docs.gitlab.com/ee/
 
    Mondoo begins scanning your GitLab group and, when completed, presents results on the INVENTORY page.
 
+## Scan GitLab Instance from GitLab CI/CD pipeline
+
+You can also set up a [GitLab pipeline](https://docs.gitlab.com/ee/ci/pipelines/) to scan your GitLab instance. This job can run at your own schedule scanning GitLab groups, GitLab projects, Terraform files and Kubernetes manifests, the same as the Mondoo hosted integration.
+This can be helpful for GitLab instances that have inbound IP allowlists set up, to restrict access to the instance. 
+
+To set up scanning from a GitLab pipeline:
+
+  - Create a personal access token (see above)
+
+  - Create Mondoo credentials
+
+  - Store those credentials in GitLab (see [Securely store credentials in GitLab](/platform/infra/supply/cicd/gitlab/#securely-store-credentials-in-gitlab))
+
+  - Store the personal access token as a variable with the name `GITLABTOKEN`
+
+Now create a GitLab pipeline by creating a [`.gitlab-ci.yml`](https://docs.gitlab.com/ee/ci/yaml/gitlab_ci_yaml.html) configuration file.
+
+This example will create a Gitlab pipeline that scans the instance it is running on using the `mondoo client` Docker image. The scan will run on a schedule you will have to define. You can change discovery options of the scan by changing the `--discover` parameter.
+
+```yml title=".gitlab-ci.yml"
+stages: [security]
+
+cnspec-gitlab-scan:
+  stage: security
+  image:
+    name: mondoo/cnspec:latest-rootless
+    entrypoint: [""]
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+  script:
+    - set -euo pipefail
+    - cnspec version
+    - cnspec scan gitlab --discover="groups, projects, terraform, k8s-manifests" --detect-cicd=0 --token "$GITLABTOKEN" --url $CI_SERVER_HOST
+
+```
+
 ## Learn more
 
 For more information, explore the complete [Mondoo GitLab Resource Pack Reference](/mql/resources/gitlab-pack/).

--- a/docs/platform/infra/saas/gitlab.mdx
+++ b/docs/platform/infra/saas/gitlab.mdx
@@ -94,16 +94,13 @@ To learn more, read [Create a personal access token](https://docs.gitlab.com/ee/
 ## Scan GitLab Instance from GitLab CI/CD pipeline
 
 You can also set up a [GitLab pipeline](https://docs.gitlab.com/ee/ci/pipelines/) to scan your GitLab instance. This job can run at your own schedule scanning GitLab groups, GitLab projects, Terraform files and Kubernetes manifests, the same as the Mondoo hosted integration.
-This can be helpful for GitLab instances that have inbound IP allowlists set up, to restrict access to the instance. 
+This can be helpful for GitLab instances that have inbound IP allowlists set up to restrict access to the instance. 
 
 To set up scanning from a GitLab pipeline:
 
   - Create a personal access token (see above)
-
   - Create Mondoo credentials
-
   - Store those credentials in GitLab (see [Securely store credentials in GitLab](/platform/infra/supply/cicd/gitlab/#securely-store-credentials-in-gitlab))
-
   - Store the personal access token as a variable with the name `GITLABTOKEN`
 
 Now create a GitLab pipeline by creating a [`.gitlab-ci.yml`](https://docs.gitlab.com/ee/ci/yaml/gitlab_ci_yaml.html) configuration file.

--- a/docs/platform/infra/supply/cicd/gitlab.md
+++ b/docs/platform/infra/supply/cicd/gitlab.md
@@ -129,4 +129,8 @@ You can copy example GitLab pipeline configs from the Mondoo Console.
 
 4. In the top-right corner of the sample config, select the copy icon to copy the config to your clipboard.
 
+## Set up a pipline to scan your GitLab instance
+
+You can set up a scan of your GitLab instance itself from within a pipeline configuration. See [Scan GitLab Instance from GitLab CI/CD pipline](/platform/infra/saas/gitlab/#scan-gitlab-instance-from-gitlab-cicd-pipeline) for more information.
+
 ---

--- a/docs/platform/infra/supply/cicd/gitlab.md
+++ b/docs/platform/infra/supply/cicd/gitlab.md
@@ -129,8 +129,8 @@ You can copy example GitLab pipeline configs from the Mondoo Console.
 
 4. In the top-right corner of the sample config, select the copy icon to copy the config to your clipboard.
 
-## Set up a pipline to scan your GitLab instance
+## Set up a pipeline to scan your GitLab instance
 
-You can set up a scan of your GitLab instance itself from within a pipeline configuration. See [Scan GitLab Instance from GitLab CI/CD pipline](/platform/infra/saas/gitlab/#scan-gitlab-instance-from-gitlab-cicd-pipeline) for more information.
+You can set up a scan of your GitLab instance itself from within a pipeline configuration. See [Scan GitLab Instance from GitLab CI/CD pipeline](/platform/infra/saas/gitlab/#scan-gitlab-instance-from-gitlab-cicd-pipeline) for more information.
 
 ---


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

#### Description

Added instructions for setting up a Gitlab pipline to scan the Gitlab instance. This would be a manual way of setting up an integration.
I was unsure of the right position of this. I linked to it from the Gitlab CI/CD instructions.

#### Related issue

Not an issue, but a customer wanted to set this up for circumventing an IP allowlist on their Gitlab instance.

#### Types of changes

<!--- What types of changes does this merge request introduce? Put an `x` in all the boxes that apply: -->

- [ ] Functional documentation bug fix (i.e., broken link or some other busted behavior)
- [ ] New functional doc capabilities (i.e., filter search results)
- [x] New content
- [ ] Revision to existing content
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

#### Checklist

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, please ask. We're here to help! -->

- [x] I have read the **README** document about contributing to this repo.
- [x] I have tested my changes locally and there are no issues.
- [x] All commits are signed.
